### PR TITLE
Update vulcanize version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mkdirp": "^0.5.0",
     "promise-map-series": "^0.2.0",
     "rsvp": "^3.0.13",
-    "vulcanize": "^0.4.2"
+    "vulcanize": "^0.7.1"
   },
   "devDependencies": {
     "broccoli": "^0.12.3",


### PR DESCRIPTION
Vulcanize 0.4.2 causes runtime errors with a number of Polymer 0.5.x elements. Updating to 0.7.1 solves the problem.
