### PR TITLE
Fix Vulcanize dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mkdirp": "^0.5.0",
     "promise-map-series": "^0.2.0",
     "rsvp": "^3.0.14",
-    "vulcanize": "^1.4.4"
+    "vulcanize": "1.5.1"
   },
   "devDependencies": {
     "broccoli": "^0.12.3",

--- a/tests/test.js
+++ b/tests/test.js
@@ -113,3 +113,20 @@ it('should accept a broccoli tree', function() {
     assert(fs.existsSync(indexHtml));
   });
 });
+
+describe('option `excludes`', function() {
+  it('should accept `RegExp[]` as input', function() {
+    var tree = vulcanize('fixtures', {
+      input: 'basic-index.html',
+      inlineCss: true,
+      excludes: [/\.css$/i],
+    });
+    builder = new Broccoli.Builder(tree);
+
+    return builder.build().then(function(result) {
+      var indexHtml = path.join(result.directory, 'basic-index.html');
+      var htmlContent = fs.readFileSync(indexHtml, 'utf8');
+      assert(htmlContent.indexOf('background-color: white;') === -1);
+    });
+  });
+});


### PR DESCRIPTION
I found that Vulcanize has changed the expected input of the `excludes` option, as described in Polymer/vulcanize#266. However, as the readme hasn't been updated, I'm not sure what value is expected in the latest versions, hence I couldn't fix the problem entirely.

This PR added a test to figure out whether Vulcanize accepts `RegExp[]` as an input for `excludes`. I then found that the latest compatible version to be `v1.5.1`, and put that into `package.json` to avoid future `npm install` grabbing the incompatible versions.